### PR TITLE
Allow non homogenous arrays

### DIFF
--- a/prettytoml/elements/array.py
+++ b/prettytoml/elements/array.py
@@ -18,7 +18,8 @@ class ArrayElement(ContainerElement, traversal.TraversalMixin):
 
     def __init__(self, sub_elements):
         common.ContainerElement.__init__(self, sub_elements)
-        self._check_homogeneity()
+        # Commenting out to avoid raising an error in cases like Poe tasks
+        #self._check_homogeneity()
 
     def _check_homogeneity(self):
         if len(set(type(v) for v in self.primitive_value)) > 1:


### PR DESCRIPTION
Currently the arrays that contain more than one type make the check raise an exception.